### PR TITLE
impl page lock on update

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub const BAD_AUTHORIZATION: u32 = 1004;
 pub const NOT_FOUND: u32 = 1005;
 /// Edits to this page have been protected.
 pub const EDITS_FORBIDDEN: u32 = 1006;
+/// The page was edited while editing.
+pub const PAGE_ALREADY_CHANGED: u32 = 1007;
 
 /// The main API error type.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -45,6 +47,7 @@ impl Error {
             BAD_AUTHORIZATION => "bad authorization, suggest: clear cache",
             NOT_FOUND => "not found",
             EDITS_FORBIDDEN => "this page is protected",
+            PAGE_ALREADY_CHANGED => "other changes were made to this page; reload",
             _ => "unknown error",
         };
 

--- a/src/page/edit.rs
+++ b/src/page/edit.rs
@@ -12,11 +12,19 @@ use serde::{Deserialize, Serialize};
 pub struct PageSource {
     /// The source content of the page.
     pub source: String,
+    /// The latest change of the hash.
+    ///
+    /// Used to protect against concurrent accesses. In the future, a better
+    /// system might be implemented.
+    pub latest_change_hash: Option<String>,
 }
 
 impl Default for PageSource {
     fn default() -> Self {
-        PageSource { source: "".into() }
+        PageSource {
+            source: "".into(),
+            latest_change_hash: None,
+        }
     }
 }
 
@@ -30,12 +38,15 @@ pub async fn get_page_source(path: String) -> Result<PageSource, ServerFnError<A
     // edits MUST be attributed
     let _token = extract_token().await?;
 
-    let content = get_page_content(&path, &state.pool)
+    let page = get_page_content(&path, &state.pool)
         .await
         .map_err(|e| ServerFnError::ServerError(e.to_string()))?;
 
-    if let Some(content) = content {
-        Ok(PageSource { source: content })
+    if let Some(page) = page {
+        Ok(PageSource {
+            source: page.content,
+            latest_change_hash: Some(page.latest_change_hash),
+        })
     } else {
         // user is trying to create page
         // send default page source as if it did exist
@@ -43,51 +54,69 @@ pub async fn get_page_source(path: String) -> Result<PageSource, ServerFnError<A
     }
 }
 
+/// Result for [`push_page_changes`]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ChangeResult {
+    /// The hash of the change.
+    ///
+    /// May be `None` if the page did not change.
+    pub hash: Option<String>,
+}
+
 /// Creates or updates a new page.
 #[server(endpoint = "/page/source")]
 pub async fn push_page_changes(
     path: String,
+    latest_change_hash: String,
     source: String,
-) -> Result<(), ServerFnError<ApiError>> {
+) -> Result<ChangeResult, ServerFnError<ApiError>> {
     use crate::{
         account::extract_token,
-        schema::page::{get_page_content, save_change, update_page_content},
+        error,
+        schema::page::{get_page_content_for_update, save_change, update_page_content},
         ServerState,
     };
     use diff_match_patch_rs::{Compat, DiffMatchPatch, PatchInput};
 
-    let state = expect_context::<ServerState>();
-
     // attribute edits on the given token
     let token = extract_token().await?;
 
-    let old_source = get_page_content(&path, &state.pool)
-        .await
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))?
-        .unwrap_or_else(String::new);
+    // Begin transaction for reading things from the db.
+    let mut tx = {
+        // keep state in this scope to prevent database access
+        let state = expect_context::<ServerState>();
+        state
+            .pool
+            .begin()
+            .await
+            .map_err(|e| ServerFnError::ServerError(format!("{:?}", e)))?
+    };
 
-    if old_source == source {
-        // bail early if the two texts are the exact same
-        return Ok(());
+    let old_page = get_page_content_for_update(&path, &mut *tx)
+        .await
+        .map_err(|e| ServerFnError::ServerError(e.to_string()))?;
+
+    if old_page.as_ref().map(|c| &c.latest_change_hash) != Some(&latest_change_hash) {
+        return Err(ApiError::from_code(error::PAGE_ALREADY_CHANGED).into());
     }
+
+    if old_page.as_ref().map(|c| &c.content) == Some(&source) {
+        // bail early if the two texts are the exact same
+        return Ok(ChangeResult { hash: None });
+    }
+
+    let old_source = old_page.as_ref().map(|c| c.content.as_str()).unwrap_or("");
 
     // do page diffing
     let dmp = DiffMatchPatch::new();
 
     let diffs = dmp
-        .diff_main::<Compat>(&old_source, &source)
+        .diff_main::<Compat>(old_source, &source)
         .map_err(|e| ServerFnError::ServerError(format!("{:?}", e)))?;
     let patches = dmp
         .patch_make(PatchInput::new_diffs(&diffs))
         .map_err(|e| ServerFnError::ServerError(format!("{:?}", e)))?;
     let changes = dmp.patch_to_text(&patches);
-
-    // save changes
-    let mut tx = state
-        .pool
-        .begin()
-        .await
-        .map_err(|e| ServerFnError::ServerError(format!("{:?}", e)))?;
 
     // make update to page content
     update_page_content(&path, &source, &mut *tx)
@@ -95,7 +124,7 @@ pub async fn push_page_changes(
         .map_err(|e| ServerFnError::ServerError(format!("{:?}", e)))?;
 
     // add change to db
-    save_change(&path, &token.sub, &changes, &mut *tx)
+    let hash = save_change(&path, &token.sub, &changes, &mut *tx)
         .await
         .map_err(|e| ServerFnError::ServerError(format!("{:?}", e)))?;
 
@@ -104,5 +133,5 @@ pub async fn push_page_changes(
         .await
         .map_err(|e| ServerFnError::ServerError(format!("{:?}", e)))?;
 
-    Ok(())
+    Ok(ChangeResult { hash: Some(hash) })
 }

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -143,7 +143,7 @@ pub fn EditPage() -> impl IntoView {
     let page_suspense = move || {
         Suspend::new(async move {
             match page.await {
-                Ok(page) => view! { <PageEditor path initial_content=page.source /> }.into_any(),
+                Ok(page) => view! { <PageEditor path page /> }.into_any(),
                 // TODO better 500 pages
                 Err(_) => view! { "error" }.into_any(),
             }

--- a/src/page/render.rs
+++ b/src/page/render.rs
@@ -38,19 +38,19 @@ pub async fn render_page(path: String) -> Result<RenderedPage, ServerFnError<Api
     let token = extract_token().await;
 
     // get page
-    let content = get_page_content(&path, &state.pool)
+    let page = get_page_content(&path, &state.pool)
         .await
         .map_err(|e| ServerFnError::ServerError(e.to_string()))?;
 
-    if let Some(content) = content {
+    if let Some(page) = page {
         let title = match path.rfind('/') {
             Some(idx) => path[idx + 1..].trim(),
             None => path.trim(),
         };
 
-        let parser = Parser::new(&content);
+        let parser = Parser::new(&page.content);
 
-        let mut html_output = String::with_capacity(content.len() * 3 / 2);
+        let mut html_output = String::with_capacity(page.content.len() * 3 / 2);
         html::push_html(&mut html_output, parser);
 
         // sanitize html


### PR DESCRIPTION
This PR should prevent changes from being made (or at least submitted) when changes have been made by other users or in other tabs/other devices.

This should also prevent any invariant bugs (concurrency bugs on calculating diffs). This makes the diff calculation a critical section, but it should be for the better to prevent weird logging.